### PR TITLE
IDEMPIERE-6546 Allow exporting tree definition with 2Pack (#2799)

### DIFF
--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PoExporter.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PoExporter.java
@@ -194,8 +194,12 @@ public class PoExporter {
 	}
 
 	public void addTableReference(String columnName, String tableName, int id, AttributesImpl atts) {
-		String value = ReferenceUtils.getTableReference(tableName, id, atts, po.get_TrxName());
-		addString(columnName, value, atts);
+		if (id == 0 && ("Node_ID".equals(columnName) || "Parent_ID".equals(columnName))) {
+			addString(columnName, "0", atts);
+		} else {
+			String value = ReferenceUtils.getTableReference(tableName, id, atts, po.get_TrxName());
+			addString(columnName, value, atts);
+		}
 	}
 
 	public void addTableReferenceUUID(String columnName, String tableName, String uuid, AttributesImpl atts) {

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PoFiller.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PoFiller.java
@@ -227,6 +227,9 @@ public class PoFiller{
 							foreignTable = MTable.get(Env.getCtx(), tableID, po.get_TrxName());
 							refTableName = foreignTable.getTableName();
 						}
+					} else if (   po.get_TableName().startsWith("AD_TreeNode")
+							   && ("Parent_ID".equalsIgnoreCase(columnName) || "Node_ID".equalsIgnoreCase(columnName))) {
+						refTableName = e.attributes.getValue("reference-key");
 					}
 				}
 				if (id instanceof Number && ((Number)id).intValue() == 0) {

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/ReferenceUtils.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/ReferenceUtils.java
@@ -122,6 +122,7 @@ public class ReferenceUtils {
 		{
 			//official id
 			atts.addAttribute("", "", "reference", "CDATA", "id");
+			atts.addAttribute("", "", "reference-key", "CDATA", tableName);
 			String value = Integer.toString(id);
 			return value;
 		}


### PR DESCRIPTION
* IDEMPIERE-6546 Allow exporting tree definition with 2Pack

- fixes for import correctly

* - add reference to ID to support import of official IDs

[ Please copy here the link to the related Jira ticket ]


# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

